### PR TITLE
fix: Update Twitter/X extraction service

### DIFF
--- a/app/api/x/extract/route.ts
+++ b/app/api/x/extract/route.ts
@@ -1,15 +1,15 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-// A simple function to extract tweet content by fetching the HTML of a service like fxtwitter.com
+// A simple function to extract tweet content by fetching the HTML of a service like twitframe.com
 // and parsing the OpenGraph meta tags. This avoids the need for a full browser or official API access.
 async function extractTweetContent(url: string): Promise<string | null> {
   try {
-    // Replace twitter.com or x.com with fxtwitter.com
-    const fxtwitterUrl = url.replace(/(twitter\.com|x\.com)/, "fxtwitter.com")
-    const response = await fetch(fxtwitterUrl)
+    // Replace twitter.com or x.com with twitframe.com
+    const twitframeUrl = url.replace(/(twitter\.com|x\.com)/, "twitframe.com")
+    const response = await fetch(twitframeUrl)
 
     if (!response.ok) {
-      throw new Error("Failed to fetch tweet content from fxtwitter")
+      throw new Error("Failed to fetch tweet content from twitframe")
     }
 
     const html = await response.text()

--- a/tests/x.api.test.ts
+++ b/tests/x.api.test.ts
@@ -1,0 +1,76 @@
+import { POST } from "@/app/api/x/extract/route"
+import { vi, describe, it, expect, afterEach } from "vitest"
+
+// Mock the global fetch function
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe("X/Twitter Extraction API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("should extract content from the og:description meta tag", async () => {
+    const mockHtml = `
+      <html>
+        <head>
+          <meta property="og:description" content="This is the tweet content." />
+        </head>
+        <body></body>
+      </html>
+    `
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () => mockHtml,
+    })
+
+    const request = {
+      json: async () => ({ url: "https://x.com/user/status/123" }),
+    } as any
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.content).toBe("This is the tweet content.")
+  })
+
+  it("should handle cases where the meta tag is not found", async () => {
+    const mockHtml = `
+      <html>
+        <head></head>
+        <body></body>
+      </html>
+    `
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () => mockHtml,
+    })
+
+    const request = {
+      json: async () => ({ url: "https://x.com/user/status/123" }),
+    } as any
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.content).toBe("[Could not extract tweet content. The post might be private, deleted, or a video.]")
+  })
+
+  it("should handle fetch errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+    })
+
+    const request = {
+      json: async () => ({ url: "https://x.com/user/status/123" }),
+    } as any
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe("Failed to extract tweet content")
+  })
+})


### PR DESCRIPTION
This commit replaces `fxtwitter.com` with `twitframe.com` for tweet content extraction to address failures caused by anti-scraping measures.

Key changes:
- Modified the `/api/x/extract` API route to use `twitframe.com`.
- Added a new test file (`tests/x.api.test.ts`) with mocked tests to verify the logic of the extraction function.
- The tests cover successful extraction, cases where the content cannot be found, and fetch errors.